### PR TITLE
fix: add trailing slashes to the urls if not present

### DIFF
--- a/admin/src/pages/Settings/Settings.tsx
+++ b/admin/src/pages/Settings/Settings.tsx
@@ -82,14 +82,16 @@ export const Settings = () => {
     mutationFn: (apiKey: string) => http.put<{ apiKey: string }, { valid: boolean }>('/settings/validate', { apiKey }),
   });
 
+  const addTrailingSlashes = (value: string) => value.endsWith('/') ? value : `${value}/`;
+
   const preparePayload = useCallback((values: FormData) => {
     const source = pickBy({
       id: values.sourceType === SOURCE_TYPES.OTHER && values.sourceId ? values.sourceId : undefined,
       type: values.sourceType,
-      url: values.sourceUrl ? values.sourceUrl : undefined,
+      url: values.sourceUrl ? addTrailingSlashes(values.sourceUrl) : undefined,
     }, (value) => value !== undefined) as ConfigData['source'];
     const payload: ConfigData = {
-      mediaLibrarySourceUrl: values.mediaLibrarySourceUrl,
+      mediaLibrarySourceUrl: values.mediaLibrarySourceUrl ? addTrailingSlashes(values.mediaLibrarySourceUrl) : values.mediaLibrarySourceUrl,
       source: isEmpty(source) ? { url: '', type: SOURCE_TYPES.FOLDER } : source,
     };
     if (values.sourceType === SOURCE_TYPES.OTHER) {


### PR DESCRIPTION
## Issue
When provided urls without trailing slashes, the replacement didn't work properly.

## Fix
Payload prepare fn runs trailing slashes check for `mediaLibrarySourceUrl` and `sourceUrl`. In case of missing, adds them.

## Tests
1. Provide values without trailing slashes
2. Submit
3. See that slashes were added when you get back to the Settings page
4. Replacement logic works as expected